### PR TITLE
Fix unused variables

### DIFF
--- a/src/get-own-property-symbols.js
+++ b/src/get-own-property-symbols.js
@@ -29,10 +29,6 @@
     hOP = ObjectProto.hasOwnProperty,
     pIE = ObjectProto[PIE],
     toString = ObjectProto.toString,
-    indexOf = Array.prototype.indexOf || function (v) {
-      for (var i = this.length; i-- && this[i] !== v;) {}
-      return i;
-    },
     addInternalIfNeeded = function (o, uid, enumerable) {
       if (!hOP.call(o, internalSymbol)) {
         defineProperty(o, internalSymbol, {
@@ -233,7 +229,7 @@
 
 }(Object, 'getOwnPropertySymbols'));
 
-(function (O, S) {
+(function (O, Symbol) {
   var
     dP = O.defineProperty,
     ObjectProto = O.prototype,


### PR DESCRIPTION
Took these changes out of https://github.com/es-shims/get-own-property-symbols/pull/14#issuecomment-425092164 for separation of reviews.