### PR TITLE
Fixed usage of create(null, undefined) in IE11

### DIFF
--- a/src/get-own-property-symbols.js
+++ b/src/get-own-property-symbols.js
@@ -190,7 +190,7 @@
   defineProperty(Object, GOPD, descriptor);
 
   descriptor.value = function (proto, descriptors) {
-    return arguments.length === 1 ?
+    return (arguments.length === 1 || typeof descriptors === "undefined") ?
       create(proto) :
       createWithSymbols(proto, descriptors);
   };

--- a/test/get-own-property-symbols.js
+++ b/test/get-own-property-symbols.js
@@ -288,6 +288,14 @@ wru.test([
       wru.assert('for real', b[s] === 'symbol');
     }
   }, {
+    name: 'Object.create(null) works',
+    test: function () {
+      var b = Object.create(null);
+      wru.assert('create works', typeof b === 'object');
+      var c = Object.create(null, undefined);
+      wru.assert('create with null,undefined works', typeof c === 'object');
+    }
+  }, {
     name: 'typeof is not string',
     test: function () {
       wru.assert(typeof Symbol('typeof') !== 'string');


### PR DESCRIPTION
This usage can come using zone.js/@webcomponents.
Thanks, L.