### PR TITLE
- Fix crash with Object.prototype.toString.call(undefined)

### DIFF
--- a/src/get-own-property-symbols.js
+++ b/src/get-own-property-symbols.js
@@ -229,7 +229,7 @@
 
 }(Object, 'getOwnPropertySymbols'));
 
-(function (O, Symbol) {
+(function (O, Symbol) {'use strict';
   var
     dP = O.defineProperty,
     ObjectProto = O.prototype,
@@ -258,9 +258,9 @@
           descriptor.value = function () {
             var
               str = toString.call(this),
-              tst = this[Symbol.toStringTag]
+              tst = this != null ? this[Symbol.toStringTag] : this
             ;
-            return typeof tst === 'undefined' ? str : ('[object ' + tst + ']');
+            return tst == null ? str : ('[object ' + tst + ']');
           };
           dP(ObjectProto, 'toString', descriptor);
           break;

--- a/test/get-own-property-symbols.js
+++ b/test/get-own-property-symbols.js
@@ -314,6 +314,12 @@ wru.test([
       wru.assert(Object.prototype.toString.call(Symbol()) === '[object Symbol]');
     }
   }, {
+    name: 'Object#toString.call(undefined | null)',
+    test: function () {
+      wru.assert(Object.prototype.toString.call(undefined) === '[object Undefined]');
+      wru.assert(Object.prototype.toString.call(null) === '[object Null]');
+    }
+  }, {
     name: 'toStringTag',
     test: function () {
       function Point() {}


### PR DESCRIPTION
Fixed crash in calling Object.prototype.toString.call(undefined) in IE11.
