### PR TITLE
fix: wrap `getOwnPropertyNames` with try/catch

### DIFF
--- a/src/get-own-property-symbols.js
+++ b/src/get-own-property-symbols.js
@@ -122,7 +122,11 @@
   defineProperty(Object, GOPS, descriptor);
 
   descriptor.value = function getOwnPropertyNames(o) {
-    return gOPN(o).filter(onlyNonSymbols);
+    try {
+      return gOPN(o).filter(onlyNonSymbols);
+    } catch (e) {
+      return [];
+    }
   };
   defineProperty(Object, GOPN, descriptor);
 


### PR DESCRIPTION
Fixes #28 

PS: wasn't sure if a test was needed. Let me know if you need one. 😃 