### PR TITLE
Fix assertion order for tests which include a description string

### DIFF
--- a/test/get-own-property-symbols.js
+++ b/test/get-own-property-symbols.js
@@ -354,7 +354,7 @@ wru.test([
       } catch(yay) {
         didTrow = true;
       }
-      wru.assert(didTrow, 'non symbols cannot be passed to keyFor');
+      wru.assert('non symbols cannot be passed to keyFor', didTrow);
     }
   }, {
     name: 'should not allow implicit string coercion',
@@ -365,7 +365,7 @@ wru.test([
       } catch(yay) {
         didTrow = true;
       }
-      wru.assert(didTrow, 'should not allow implicit string coercion');
+      wru.assert('should not allow implicit string coercion', didTrow);
     }
   }, {
     name: 'silently fail when overwriting properties',


### PR DESCRIPTION
description strings are the last argument to wru, the first argument is the assertion being made

This should have some failing tests as I know this polyfill does not stop implicit string coercion of symbols.